### PR TITLE
Remove locks when jobs die

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Log details of enqueued subscription
 
+### Fixed
+- Remove locks when jobs die
+
 ## [0.2.2] - 2018-09-15
 ### Fixed
 - Problem where only one of two subscription workers were enqueued. Previous "fix" didn't work

--- a/lib/message_bus_client_worker.rb
+++ b/lib/message_bus_client_worker.rb
@@ -28,4 +28,15 @@ module MessageBusClientWorker
     has :subscriptions, classes: Hash
   end
 
+  def self.config_sidekiq!
+    Sidekiq.configure_server do |config|
+      config.death_handlers << ->(job, _ex) do
+        return unless job['unique_digest']
+        SidekiqUniqueJobs::Digests.del(digest: job['unique_digest'])
+      end
+    end
+  end
+
 end
+
+MessageBusClientWorker.config_sidekiq!


### PR DESCRIPTION
When jobs die, the unique lock is not removed. This fixes it.