### PR TITLE
Set retry to 0 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2018-10-07
+### Fixed
+- SubscriptionWorker retry is `0` so death handlers are executed
+
 ## [0.3.0] - 2018-09-24
 ### Added
 - Log details of enqueued subscription

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    message_bus_client_worker (0.3.0)
+    message_bus_client_worker (0.3.1)
       activesupport
       addressable
       gem_config

--- a/lib/message_bus_client_worker/version.rb
+++ b/lib/message_bus_client_worker/version.rb
@@ -1,3 +1,3 @@
 module MessageBusClientWorker
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end

--- a/lib/message_bus_client_worker/workers/subscription_worker.rb
+++ b/lib/message_bus_client_worker/workers/subscription_worker.rb
@@ -3,7 +3,7 @@ module MessageBusClientWorker
 
     include Sidekiq::Worker
     sidekiq_options(
-      retry: false,
+      retry: 0,
       lock: :until_executed,
       unique_args: :unique_args,
       on_conflict: :log,

--- a/spec/lib/message_bus_client_worker/workers/subscription_worker_spec.rb
+++ b/spec/lib/message_bus_client_worker/workers/subscription_worker_spec.rb
@@ -3,7 +3,9 @@ require 'spec_helper'
 module MessageBusClientWorker
   RSpec.describe SubscriptionWorker do
 
-    it { is_expected.to be_retryable(false) }
+    # NOTE: death handlers are not executed with retry false until
+    # https://github.com/mperham/sidekiq/pull/3980
+    it { is_expected.to be_retryable(0) }
 
     it "is supposed to not allow enqueuing of the same job until the job is done" do
       expect(described_class.sidekiq_options["lock"]).to eq :until_executed


### PR DESCRIPTION
SubscriptionWorker retry is `0` so death handlers are executed. See https://github.com/mperham/sidekiq/pull/3980