### PR TITLE
WIP: Do not immediately raise an exception when site is down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Changed
 - Change to excon. We know how to stream with that (make way for long polling)
+- Do not immediately raise errors when there's a problem connecting
 
 ## [0.3.1] - 2018-10-07
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,8 +4,10 @@ PATH
     message_bus_client_worker (0.3.1)
       activesupport
       addressable
+      circuitbox (>= 1.0)
       excon
       gem_config
+      http
       light-service
       sidekiq (>= 5.1)
       sidekiq-unique-jobs (>= 6.0.0)
@@ -13,7 +15,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.1)
+    activesupport (5.2.1.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -21,18 +23,33 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     byebug (10.0.2)
+    circuitbox (1.1.1)
+      activesupport
+      moneta
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
     connection_pool (2.2.2)
     diff-lcs (1.3)
+    domain_name (0.5.20180417)
+      unf (>= 0.0.5, < 1.0.0)
     excon (0.62.0)
     gem_config (0.3.1)
+    http (4.0.0)
+      addressable (~> 2.3)
+      http-cookie (~> 1.0)
+      http-form_data (~> 2.0)
+      http_parser.rb (~> 0.6.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
+    http-form_data (2.1.1)
+    http_parser.rb (0.6.0)
     i18n (1.1.1)
       concurrent-ruby (~> 1.0)
     light-service (0.11.0)
       activesupport (>= 3.0)
     method_source (0.9.0)
     minitest (5.11.3)
+    moneta (1.0.0)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -66,7 +83,7 @@ GEM
       connection_pool (~> 2.2, >= 2.2.0)
       rack-protection (>= 1.5.0)
       redis (>= 3.3.5, < 5)
-    sidekiq-unique-jobs (6.0.6)
+    sidekiq-unique-jobs (6.0.7)
       concurrent-ruby (~> 1.0, >= 1.0.5)
       sidekiq (>= 4.0, < 6.0)
       thor (~> 0)
@@ -74,6 +91,9 @@ GEM
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.5)
     wait (0.5.3)
 
 PLATFORMS
@@ -89,4 +109,4 @@ DEPENDENCIES
   wait
 
 BUNDLED WITH
-   1.16.4
+   1.16.6

--- a/lib/message_bus_client_worker.rb
+++ b/lib/message_bus_client_worker.rb
@@ -1,4 +1,5 @@
 require "addressable"
+require "circuitbox"
 require "excon"
 require "gem_config"
 require "light-service"
@@ -7,6 +8,11 @@ require "sidekiq"
 require "sidekiq-unique-jobs"
 require "active_support/core_ext/hash/indifferent_access"
 require "active_support/core_ext/string/inflections"
+
+# exceptions raised by Excon when calls fail are in http
+# but for some reason, I need to require the gem myself
+require "http"
+
 require "message_bus_client_worker/version"
 require "message_bus_client_worker/workers/enqueuing_worker"
 require "message_bus_client_worker/workers/subscription_worker"

--- a/lib/message_bus_client_worker/services/polling/get_payloads.rb
+++ b/lib/message_bus_client_worker/services/polling/get_payloads.rb
@@ -3,15 +3,31 @@ module MessageBusClientWorker
     class GetPayloads
       extend LightService::Action
 
+      EXCEPTIONS = [
+        HTTP::ConnectionError,
+      ]
       expects :params, :form_params, :uri
       promises :payloads
 
       executed do |c|
-        response = Excon.post(c.uri, {
-          query: c.params,
-          body: URI.encode_www_form(c.form_params)
-        })
+        response = excon_circuit.run do
+          Excon.post(c.uri, {
+            query: c.params,
+            body: URI.encode_www_form(c.form_params)
+          })
+        end
+
+        if response.nil?
+          c.fail_and_return!("Unable to connect to #{c.uri}")
+        end
+
         c.payloads = JSON.parse(response.body.to_s)
+      end
+
+      def self.excon_circuit
+        Circuitbox.circuit(:message_bus_client_worker_excon, {
+          exceptions: EXCEPTIONS,
+        })
       end
     end
   end

--- a/message_bus_client_worker.gemspec
+++ b/message_bus_client_worker.gemspec
@@ -37,6 +37,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency "light-service"
   spec.add_dependency "sidekiq-unique-jobs", ">= 6.0.0"
   spec.add_dependency "activesupport"
+  spec.add_dependency "circuitbox", ">= 1.0"
+  spec.add_dependency "http"
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/spec/lib/message_bus_client_worker/services/polling/get_payloads_spec.rb
+++ b/spec/lib/message_bus_client_worker/services/polling/get_payloads_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+module MessageBusClientWorker
+  module Polling
+    RSpec.describe GetPayloads do
+
+      context "circuit is open or call failed" do
+        it "fails the context" do
+          expect(Excon).to receive(:post)
+            .and_raise(described_class::EXCEPTIONS.sample)
+
+          result = described_class.execute({
+            params: {},
+            form_params: {},
+            uri: "hi.com",
+          })
+
+          expect(result).to be_failure
+          expect(result).to be_stop_processing
+        end
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
When the site being connected to goes down, it makes all subscriptions blow up. This makes the exceptions very noisy. The expections of MB is that it will eventually fetch the data

NOTE: I think circuitbox will never reraise exceptions; the circuit will just keep opening and closing