### PR TITLE
feat: subscribe hook

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,32 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
+# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
+
+name: Ruby
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7.0
+    - name: Start dbs
+      run: docker-compose up --detach sidekiq chat
+    - name: Copy config
+      run: cp spec/config.yml{.sample,}
+    - name: Run tests
+      run: docker-compose run gem bundle exec rspec spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-sudo: false
-language: ruby
-rvm:
-  - 2.6.3
-before_script:
-  - cp spec/config.yml{.sample,}
-  - docker-compose up -d sidekiq chat
-script: docker-compose run gem bundle exec rspec spec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.1.0] - 2021-10-01
 ### Added
 - `MessageBusClientWorker.subscribe(host, config)` which recommended over setting subscriptions via `configure`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- `MessageBusClientWorker.subscribe(host, config)` which recommended over setting subscriptions via `configure`
+
 ## [2.0.0] - 2020-03-12
 ### Changed
 - Update logging in Sidekiq; requires Sidekiq 6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    message_bus_client_worker (2.0.0)
+    message_bus_client_worker (2.1.0)
       activesupport
       addressable
       excon
@@ -12,33 +12,34 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.2.1)
+    activesupport (6.1.4.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
-      zeitwerk (~> 2.2)
-    addressable (2.7.0)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
+    addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     byebug (10.0.2)
     coderay (1.1.2)
-    concurrent-ruby (1.1.6)
+    concurrent-ruby (1.1.9)
     connection_pool (2.2.2)
     diff-lcs (1.3)
-    excon (0.72.0)
+    excon (0.85.0)
     gem_config (0.3.2)
-    i18n (1.8.2)
+    i18n (1.8.10)
       concurrent-ruby (~> 1.0)
-    light-service (0.12.0)
+    light-service (0.17.0)
+      activesupport (>= 4.0.0)
     method_source (0.9.0)
-    minitest (5.14.0)
+    minitest (5.14.4)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     pry-byebug (3.6.0)
       byebug (~> 10.0)
       pry (~> 0.10)
-    public_suffix (4.0.3)
+    public_suffix (4.0.6)
     rack (2.2.2)
     rack-protection (2.0.8.1)
       rack
@@ -65,11 +66,10 @@ GEM
       rack (~> 2.0)
       rack-protection (>= 2.0.0)
       redis (>= 4.1.0)
-    thread_safe (0.3.6)
-    tzinfo (1.2.6)
-      thread_safe (~> 0.1)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
     wait (0.5.3)
-    zeitwerk (2.3.0)
+    zeitwerk (2.4.2)
 
 PLATFORMS
   ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.16)
   message_bus_client_worker!
   pry-byebug
   rake (~> 10.0)
@@ -84,4 +83,4 @@ DEPENDENCIES
   wait
 
 BUNDLED WITH
-   1.17.3
+   2.2.28

--- a/lib/message_bus_client_worker.rb
+++ b/lib/message_bus_client_worker.rb
@@ -26,8 +26,18 @@ module MessageBusClientWorker
   include GemConfig::Base
 
   with_configuration do
-    has :subscriptions, classes: Hash
+    has :subscriptions, classes: [Hash, NilClass]
     has :client_id, classes: [Proc, String], default: -> {SecureRandom.uuid}
+  end
+
+  def self.subscribe(host, options)
+    self.configuration.subscriptions ||= {}
+
+    if self.configuration.subscriptions.keys.include?(host)
+      warn "[#{self.name}] #{host} already configured, overwriting (called from #{caller.first})"
+    end
+
+    self.configuration.subscriptions[host] = options
   end
 
 end

--- a/lib/message_bus_client_worker/version.rb
+++ b/lib/message_bus_client_worker/version.rb
@@ -1,3 +1,3 @@
 module MessageBusClientWorker
-  VERSION = "2.0.0"
+  VERSION = "2.1.0"
 end

--- a/message_bus_client_worker.gemspec
+++ b/message_bus_client_worker.gemspec
@@ -37,7 +37,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "light-service"
   spec.add_dependency "activesupport"
 
-  spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec-sidekiq"


### PR DESCRIPTION
Add `MessageBusClientWorker.subscribe(host, config)` which is recommended over setting subscriptions via `configure`

This should be used over setting subscriptions directly in
the configure block.

This method makes it easier for multiple gems that use MBCW
to not overwrite one another's subscriptions. It is clear that
the subscriptions will not be overwritten, unlike `subscriptions=`