### PR TITLE
fix: do not blow up with Sidekiq 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Support for Sidekiq 7 or when `Sidekiq.strict_args!` is called
+
 ## [2.1.0] - 2021-10-01
 ### Added
 - `MessageBusClientWorker.subscribe(host, config)` which recommended over setting subscriptions via `configure`

--- a/lib/message_bus_client_worker/workers/enqueuing_worker.rb
+++ b/lib/message_bus_client_worker/workers/enqueuing_worker.rb
@@ -6,7 +6,7 @@ module MessageBusClientWorker
 
     def perform
       MessageBusClientWorker.configuration.subscriptions.each do |host, subs|
-        SubscriptionWorker.perform_async(host, subs)
+        SubscriptionWorker.perform_async(host, subs.to_json)
       end
     end
 

--- a/lib/message_bus_client_worker/workers/subscription_worker.rb
+++ b/lib/message_bus_client_worker/workers/subscription_worker.rb
@@ -4,9 +4,11 @@ module MessageBusClientWorker
     include Sidekiq::Worker
     sidekiq_options retry: 0
 
-    def perform(host, subscriptions, long = false)
-      log(host, subscriptions.with_indifferent_access)
-      Poll.call(host, subscriptions.with_indifferent_access, long)
+    def perform(host, subscriptions_json, long = false)
+      subscriptions = JSON.parse(subscriptions_json).with_indifferent_access
+
+      log(host, subscriptions)
+      Poll.call(host, subscriptions, long)
     end
 
     private

--- a/spec/lib/message_bus_client_worker/workers/enqueuing_worker_spec.rb
+++ b/spec/lib/message_bus_client_worker/workers/enqueuing_worker_spec.rb
@@ -22,14 +22,14 @@ module MessageBusClientWorker
 
       expect(SubscriptionWorker).to have_enqueued_sidekiq_job(
         "https://chat.samsaffron.com",
-        "/message" => "MessageProcessor",
+        {"/message" => "MessageProcessor"}.to_json,
       )
       expect(SubscriptionWorker).to have_enqueued_sidekiq_job(
         "https://other.com",
         {
           "/fake" => "FakeProcessor",
           "/still_fake" => "StillFakeProcessor",
-        }
+        }.to_json
       )
     end
 

--- a/spec/lib/message_bus_client_worker/workers/subscription_worker_spec.rb
+++ b/spec/lib/message_bus_client_worker/workers/subscription_worker_spec.rb
@@ -5,18 +5,22 @@ module MessageBusClientWorker
 
     it { is_expected.to be_retryable(0) }
 
-    it "delegates work to Poll" do
-      params = { processor: "Processor" }
-      subscriptions = {
-        headers: { "Authorization" => "Bearer me" },
-        channels: { "/messages" => params }
-      }
+    describe "#perform" do
+      let(:params) { { processor: "Processor" } }
+      let(:subscriptions_hash) do
+        {
+          headers: { "Authorization" => "Bearer me" },
+          channels: { "/messages" => params }
+        }
+      end
 
-      expect(Poll).to receive(:call).
-        with("https://host.com", subscriptions, true)
+      it "delegates work to Poll" do
+        expect(Poll).to receive(:call).
+          with("https://host.com", subscriptions_hash, true)
 
-      described_class.new.
-        perform("https://host.com", subscriptions, true)
+        described_class.new.
+          perform("https://host.com", subscriptions_hash.to_json, true)
+      end
     end
 
   end


### PR DESCRIPTION
Sidekiq 7 will raise an exception if a Ruby hash is passed onto the worker; instead, pass in JSON and parse it for use later